### PR TITLE
fix(deps): use ladybug-core instead of ladybug-geometry

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -13,4 +13,3 @@ wheel==0.36.2
 setuptools==57.0.0
 importlib-metadata==4.3.1
 pydantic==1.8.2
-ladybug-core==0.39.25

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-ladybug-geometry==1.23.19
+ladybug-core==0.39.25
 vtk==9.1.0


### PR DESCRIPTION
This was the wrong suggestion by me. We need the ladybug-core library as a dependency to be able to access the classes from the `_extend_ladybug` module.