### PR TITLE
fix(text alignment): fix the case for upside down text

### DIFF
--- a/ladybug_vtk/from_geometry.py
+++ b/ladybug_vtk/from_geometry.py
@@ -545,6 +545,13 @@ def from_text(
             angle = math.degrees(angle_rad)
             if angle > 0.1:
                 vector = rotated_plane.n
+                # this is an edge case that I couldn't really figure out why is happening
+                # we should try to find a more generic solution. Use the simple_box.vsf
+                # sample file for testing
+                if rotated_plane.x.angle(Vector3D(0, 0, 1)) < 0.01 and \
+                        plane.x.angle(Vector3D(0, -1, 0)) < 0.01 and \
+                        vector.angle(Vector3D(-1, 0, 0)) < 0.01:
+                    vector = Vector3D(1, 0, 0)
                 transform.RotateWXYZ(angle, vector.x, vector.y, vector.z)
                 rotated_plane = rotated_plane.rotate(vector, angle_rad, original_plane.o)
 

--- a/tests/assets/simple_box.vsf
+++ b/tests/assets/simple_box.vsf
@@ -1,0 +1,820 @@
+{
+    "type": "VisualizationSet",
+    "identifier": "unnamed_cecd206a",
+    "geometry": [
+        {
+            "type": "ContextGeometry",
+            "identifier": "Face_properties.energy.construction.display_name",
+            "geometry": [
+                {
+                    "type": "DisplayText3D",
+                    "text": "Generic Exterior Wall 0",
+                    "plane": {
+                        "type": "Plane",
+                        "n": [
+                            0.0,
+                            -1.0,
+                            0.0
+                        ],
+                        "o": [
+                            5.0,
+                            0.0,
+                            1.4047619047619047
+                        ],
+                        "x": [
+                            1.0,
+                            0.0,
+                            -1.2246467991473532e-16
+                        ]
+                    },
+                    "height": 0.09523809523809523,
+                    "color": {
+                        "r": 0,
+                        "g": 0,
+                        "b": 0,
+                        "a": 255,
+                        "type": "Color"
+                    },
+                    "font": "Arial",
+                    "horizontal_alignment": "Center",
+                    "vertical_alignment": "Middle"
+                },
+                {
+                    "type": "DisplayText3D",
+                    "text": "Generic Exterior Wall 1",
+                    "plane": {
+                        "type": "Plane",
+                        "n": [
+                            1.0,
+                            0.0,
+                            0.0
+                        ],
+                        "o": [
+                            10.0,
+                            5.0,
+                            1.4047619047619047
+                        ],
+                        "x": [
+                            0.0,
+                            1.0,
+                            -1.2246467991473532e-16
+                        ]
+                    },
+                    "height": 0.09523809523809523,
+                    "color": {
+                        "r": 0,
+                        "g": 0,
+                        "b": 0,
+                        "a": 255,
+                        "type": "Color"
+                    },
+                    "font": "Arial",
+                    "horizontal_alignment": "Center",
+                    "vertical_alignment": "Middle"
+                },
+                {
+                    "type": "DisplayText3D",
+                    "text": "Generic Exterior Wall 2",
+                    "plane": {
+                        "type": "Plane",
+                        "n": [
+                            0.0,
+                            1.0,
+                            0.0
+                        ],
+                        "o": [
+                            5.0,
+                            10.0,
+                            1.4047619047619047
+                        ],
+                        "x": [
+                            -1.0,
+                            0.0,
+                            -1.2246467991473532e-16
+                        ]
+                    },
+                    "height": 0.09523809523809523,
+                    "color": {
+                        "r": 0,
+                        "g": 0,
+                        "b": 0,
+                        "a": 255,
+                        "type": "Color"
+                    },
+                    "font": "Arial",
+                    "horizontal_alignment": "Center",
+                    "vertical_alignment": "Middle"
+                },
+                {
+                    "type": "DisplayText3D",
+                    "text": "Generic Exterior Wall 3",
+                    "plane": {
+                        "type": "Plane",
+                        "n": [
+                            -1.0,
+                            0.0,
+                            0.0
+                        ],
+                        "o": [
+                            0.0,
+                            5.0,
+                            1.5952380952380953
+                        ],
+                        "x": [
+                            0.0,
+                            -1.0,
+                            0
+                        ]
+                    },
+                    "height": 0.09523809523809523,
+                    "color": {
+                        "r": 0,
+                        "g": 0,
+                        "b": 0,
+                        "a": 255,
+                        "type": "Color"
+                    },
+                    "font": "Arial",
+                    "horizontal_alignment": "Center",
+                    "vertical_alignment": "Middle"
+                },
+                {
+                    "type": "DisplayText3D",
+                    "text": "Generic Ground Slab",
+                    "plane": {
+                        "type": "Plane",
+                        "n": [
+                            0.0,
+                            0.0,
+                            -1.0
+                        ],
+                        "o": [
+                            5.0,
+                            4.75,
+                            0.0
+                        ],
+                        "x": [
+                            1.0,
+                            0.0,
+                            0.0
+                        ]
+                    },
+                    "height": 0.25,
+                    "color": {
+                        "r": 0,
+                        "g": 0,
+                        "b": 0,
+                        "a": 255,
+                        "type": "Color"
+                    },
+                    "font": "Arial",
+                    "horizontal_alignment": "Center",
+                    "vertical_alignment": "Middle"
+                },
+                {
+                    "type": "DisplayText3D",
+                    "text": "Generic Roof",
+                    "plane": {
+                        "type": "Plane",
+                        "n": [
+                            0.0,
+                            0.0,
+                            1.0
+                        ],
+                        "o": [
+                            5.0,
+                            4.75,
+                            3.0
+                        ],
+                        "x": [
+                            1.0,
+                            0.0,
+                            0.0
+                        ]
+                    },
+                    "height": 0.25,
+                    "color": {
+                        "r": 0,
+                        "g": 0,
+                        "b": 0,
+                        "a": 255,
+                        "type": "Color"
+                    },
+                    "font": "Arial",
+                    "horizontal_alignment": "Center",
+                    "vertical_alignment": "Middle"
+                }
+            ],
+            "hidden": false,
+            "display_name": "Face Construction"
+        },
+        {
+            "type": "ContextGeometry",
+            "identifier": "Wireframe",
+            "geometry": [
+                {
+                    "type": "DisplayLineSegment3D",
+                    "geometry": {
+                        "p": [
+                            0.0,
+                            0.0,
+                            3.0
+                        ],
+                        "v": [
+                            0.0,
+                            0.0,
+                            -3.0
+                        ],
+                        "type": "LineSegment3D"
+                    },
+                    "color": {
+                        "r": 0,
+                        "g": 0,
+                        "b": 0,
+                        "a": 255,
+                        "type": "Color"
+                    },
+                    "line_width": 2.0,
+                    "line_type": "Continuous"
+                },
+                {
+                    "type": "DisplayLineSegment3D",
+                    "geometry": {
+                        "p": [
+                            0.0,
+                            0.0,
+                            0.0
+                        ],
+                        "v": [
+                            10.0,
+                            0.0,
+                            0.0
+                        ],
+                        "type": "LineSegment3D"
+                    },
+                    "color": {
+                        "r": 0,
+                        "g": 0,
+                        "b": 0,
+                        "a": 255,
+                        "type": "Color"
+                    },
+                    "line_width": 2.0,
+                    "line_type": "Continuous"
+                },
+                {
+                    "type": "DisplayLineSegment3D",
+                    "geometry": {
+                        "p": [
+                            10.0,
+                            0.0,
+                            0.0
+                        ],
+                        "v": [
+                            0.0,
+                            0.0,
+                            3.0
+                        ],
+                        "type": "LineSegment3D"
+                    },
+                    "color": {
+                        "r": 0,
+                        "g": 0,
+                        "b": 0,
+                        "a": 255,
+                        "type": "Color"
+                    },
+                    "line_width": 2.0,
+                    "line_type": "Continuous"
+                },
+                {
+                    "type": "DisplayLineSegment3D",
+                    "geometry": {
+                        "p": [
+                            10.0,
+                            0.0,
+                            3.0
+                        ],
+                        "v": [
+                            -10.0,
+                            0.0,
+                            0.0
+                        ],
+                        "type": "LineSegment3D"
+                    },
+                    "color": {
+                        "r": 0,
+                        "g": 0,
+                        "b": 0,
+                        "a": 255,
+                        "type": "Color"
+                    },
+                    "line_width": 2.0,
+                    "line_type": "Continuous"
+                },
+                {
+                    "type": "DisplayLineSegment3D",
+                    "geometry": {
+                        "p": [
+                            10.0,
+                            0.0,
+                            3.0
+                        ],
+                        "v": [
+                            0.0,
+                            0.0,
+                            -3.0
+                        ],
+                        "type": "LineSegment3D"
+                    },
+                    "color": {
+                        "r": 0,
+                        "g": 0,
+                        "b": 0,
+                        "a": 255,
+                        "type": "Color"
+                    },
+                    "line_width": 2.0,
+                    "line_type": "Continuous"
+                },
+                {
+                    "type": "DisplayLineSegment3D",
+                    "geometry": {
+                        "p": [
+                            10.0,
+                            0.0,
+                            0.0
+                        ],
+                        "v": [
+                            0.0,
+                            10.0,
+                            0.0
+                        ],
+                        "type": "LineSegment3D"
+                    },
+                    "color": {
+                        "r": 0,
+                        "g": 0,
+                        "b": 0,
+                        "a": 255,
+                        "type": "Color"
+                    },
+                    "line_width": 2.0,
+                    "line_type": "Continuous"
+                },
+                {
+                    "type": "DisplayLineSegment3D",
+                    "geometry": {
+                        "p": [
+                            10.0,
+                            10.0,
+                            0.0
+                        ],
+                        "v": [
+                            0.0,
+                            0.0,
+                            3.0
+                        ],
+                        "type": "LineSegment3D"
+                    },
+                    "color": {
+                        "r": 0,
+                        "g": 0,
+                        "b": 0,
+                        "a": 255,
+                        "type": "Color"
+                    },
+                    "line_width": 2.0,
+                    "line_type": "Continuous"
+                },
+                {
+                    "type": "DisplayLineSegment3D",
+                    "geometry": {
+                        "p": [
+                            10.0,
+                            10.0,
+                            3.0
+                        ],
+                        "v": [
+                            0.0,
+                            -10.0,
+                            0.0
+                        ],
+                        "type": "LineSegment3D"
+                    },
+                    "color": {
+                        "r": 0,
+                        "g": 0,
+                        "b": 0,
+                        "a": 255,
+                        "type": "Color"
+                    },
+                    "line_width": 2.0,
+                    "line_type": "Continuous"
+                },
+                {
+                    "type": "DisplayLineSegment3D",
+                    "geometry": {
+                        "p": [
+                            10.0,
+                            10.0,
+                            3.0
+                        ],
+                        "v": [
+                            0.0,
+                            0.0,
+                            -3.0
+                        ],
+                        "type": "LineSegment3D"
+                    },
+                    "color": {
+                        "r": 0,
+                        "g": 0,
+                        "b": 0,
+                        "a": 255,
+                        "type": "Color"
+                    },
+                    "line_width": 2.0,
+                    "line_type": "Continuous"
+                },
+                {
+                    "type": "DisplayLineSegment3D",
+                    "geometry": {
+                        "p": [
+                            10.0,
+                            10.0,
+                            0.0
+                        ],
+                        "v": [
+                            -10.0,
+                            0.0,
+                            0.0
+                        ],
+                        "type": "LineSegment3D"
+                    },
+                    "color": {
+                        "r": 0,
+                        "g": 0,
+                        "b": 0,
+                        "a": 255,
+                        "type": "Color"
+                    },
+                    "line_width": 2.0,
+                    "line_type": "Continuous"
+                },
+                {
+                    "type": "DisplayLineSegment3D",
+                    "geometry": {
+                        "p": [
+                            0.0,
+                            10.0,
+                            0.0
+                        ],
+                        "v": [
+                            0.0,
+                            0.0,
+                            3.0
+                        ],
+                        "type": "LineSegment3D"
+                    },
+                    "color": {
+                        "r": 0,
+                        "g": 0,
+                        "b": 0,
+                        "a": 255,
+                        "type": "Color"
+                    },
+                    "line_width": 2.0,
+                    "line_type": "Continuous"
+                },
+                {
+                    "type": "DisplayLineSegment3D",
+                    "geometry": {
+                        "p": [
+                            0.0,
+                            10.0,
+                            3.0
+                        ],
+                        "v": [
+                            10.0,
+                            0.0,
+                            0.0
+                        ],
+                        "type": "LineSegment3D"
+                    },
+                    "color": {
+                        "r": 0,
+                        "g": 0,
+                        "b": 0,
+                        "a": 255,
+                        "type": "Color"
+                    },
+                    "line_width": 2.0,
+                    "line_type": "Continuous"
+                },
+                {
+                    "type": "DisplayLineSegment3D",
+                    "geometry": {
+                        "p": [
+                            0.0,
+                            10.0,
+                            3.0
+                        ],
+                        "v": [
+                            0.0,
+                            0.0,
+                            -3.0
+                        ],
+                        "type": "LineSegment3D"
+                    },
+                    "color": {
+                        "r": 0,
+                        "g": 0,
+                        "b": 0,
+                        "a": 255,
+                        "type": "Color"
+                    },
+                    "line_width": 2.0,
+                    "line_type": "Continuous"
+                },
+                {
+                    "type": "DisplayLineSegment3D",
+                    "geometry": {
+                        "p": [
+                            0.0,
+                            10.0,
+                            0.0
+                        ],
+                        "v": [
+                            0.0,
+                            -10.0,
+                            0.0
+                        ],
+                        "type": "LineSegment3D"
+                    },
+                    "color": {
+                        "r": 0,
+                        "g": 0,
+                        "b": 0,
+                        "a": 255,
+                        "type": "Color"
+                    },
+                    "line_width": 2.0,
+                    "line_type": "Continuous"
+                },
+                {
+                    "type": "DisplayLineSegment3D",
+                    "geometry": {
+                        "p": [
+                            0.0,
+                            0.0,
+                            0.0
+                        ],
+                        "v": [
+                            0.0,
+                            0.0,
+                            3.0
+                        ],
+                        "type": "LineSegment3D"
+                    },
+                    "color": {
+                        "r": 0,
+                        "g": 0,
+                        "b": 0,
+                        "a": 255,
+                        "type": "Color"
+                    },
+                    "line_width": 2.0,
+                    "line_type": "Continuous"
+                },
+                {
+                    "type": "DisplayLineSegment3D",
+                    "geometry": {
+                        "p": [
+                            0.0,
+                            0.0,
+                            3.0
+                        ],
+                        "v": [
+                            0.0,
+                            10.0,
+                            0.0
+                        ],
+                        "type": "LineSegment3D"
+                    },
+                    "color": {
+                        "r": 0,
+                        "g": 0,
+                        "b": 0,
+                        "a": 255,
+                        "type": "Color"
+                    },
+                    "line_width": 2.0,
+                    "line_type": "Continuous"
+                },
+                {
+                    "type": "DisplayLineSegment3D",
+                    "geometry": {
+                        "p": [
+                            10.0,
+                            10.0,
+                            0.0
+                        ],
+                        "v": [
+                            0.0,
+                            -10.0,
+                            0.0
+                        ],
+                        "type": "LineSegment3D"
+                    },
+                    "color": {
+                        "r": 0,
+                        "g": 0,
+                        "b": 0,
+                        "a": 255,
+                        "type": "Color"
+                    },
+                    "line_width": 2.0,
+                    "line_type": "Continuous"
+                },
+                {
+                    "type": "DisplayLineSegment3D",
+                    "geometry": {
+                        "p": [
+                            10.0,
+                            0.0,
+                            0.0
+                        ],
+                        "v": [
+                            -10.0,
+                            0.0,
+                            0.0
+                        ],
+                        "type": "LineSegment3D"
+                    },
+                    "color": {
+                        "r": 0,
+                        "g": 0,
+                        "b": 0,
+                        "a": 255,
+                        "type": "Color"
+                    },
+                    "line_width": 2.0,
+                    "line_type": "Continuous"
+                },
+                {
+                    "type": "DisplayLineSegment3D",
+                    "geometry": {
+                        "p": [
+                            0.0,
+                            0.0,
+                            0.0
+                        ],
+                        "v": [
+                            0.0,
+                            10.0,
+                            0.0
+                        ],
+                        "type": "LineSegment3D"
+                    },
+                    "color": {
+                        "r": 0,
+                        "g": 0,
+                        "b": 0,
+                        "a": 255,
+                        "type": "Color"
+                    },
+                    "line_width": 2.0,
+                    "line_type": "Continuous"
+                },
+                {
+                    "type": "DisplayLineSegment3D",
+                    "geometry": {
+                        "p": [
+                            0.0,
+                            10.0,
+                            0.0
+                        ],
+                        "v": [
+                            10.0,
+                            0.0,
+                            0.0
+                        ],
+                        "type": "LineSegment3D"
+                    },
+                    "color": {
+                        "r": 0,
+                        "g": 0,
+                        "b": 0,
+                        "a": 255,
+                        "type": "Color"
+                    },
+                    "line_width": 2.0,
+                    "line_type": "Continuous"
+                },
+                {
+                    "type": "DisplayLineSegment3D",
+                    "geometry": {
+                        "p": [
+                            0.0,
+                            10.0,
+                            3.0
+                        ],
+                        "v": [
+                            0.0,
+                            -10.0,
+                            0.0
+                        ],
+                        "type": "LineSegment3D"
+                    },
+                    "color": {
+                        "r": 0,
+                        "g": 0,
+                        "b": 0,
+                        "a": 255,
+                        "type": "Color"
+                    },
+                    "line_width": 2.0,
+                    "line_type": "Continuous"
+                },
+                {
+                    "type": "DisplayLineSegment3D",
+                    "geometry": {
+                        "p": [
+                            0.0,
+                            0.0,
+                            3.0
+                        ],
+                        "v": [
+                            10.0,
+                            0.0,
+                            0.0
+                        ],
+                        "type": "LineSegment3D"
+                    },
+                    "color": {
+                        "r": 0,
+                        "g": 0,
+                        "b": 0,
+                        "a": 255,
+                        "type": "Color"
+                    },
+                    "line_width": 2.0,
+                    "line_type": "Continuous"
+                },
+                {
+                    "type": "DisplayLineSegment3D",
+                    "geometry": {
+                        "p": [
+                            10.0,
+                            0.0,
+                            3.0
+                        ],
+                        "v": [
+                            0.0,
+                            10.0,
+                            0.0
+                        ],
+                        "type": "LineSegment3D"
+                    },
+                    "color": {
+                        "r": 0,
+                        "g": 0,
+                        "b": 0,
+                        "a": 255,
+                        "type": "Color"
+                    },
+                    "line_width": 2.0,
+                    "line_type": "Continuous"
+                },
+                {
+                    "type": "DisplayLineSegment3D",
+                    "geometry": {
+                        "p": [
+                            10.0,
+                            10.0,
+                            3.0
+                        ],
+                        "v": [
+                            -10.0,
+                            0.0,
+                            0.0
+                        ],
+                        "type": "LineSegment3D"
+                    },
+                    "color": {
+                        "r": 0,
+                        "g": 0,
+                        "b": 0,
+                        "a": 255,
+                        "type": "Color"
+                    },
+                    "line_width": 2.0,
+                    "line_type": "Continuous"
+                }
+            ],
+            "hidden": false
+        }
+    ],
+    "display_name": "unnamed"
+}


### PR DESCRIPTION
I'm not really proud of this solution but it will get us over the line until I find a more generic solution to catch this case.

What is happening is that in a very particular case the right hand rule results in a upside-down text. I'm catching the case and flipping the rotation normal.